### PR TITLE
Created a custom error type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -26,21 +26,24 @@ impl<I2cE> From<I2cE> for Sh1107gError<I2cE> {
 
 // src/main.rs または専用のerrorsモジュールに記述
 #[derive(Debug)]
-pub enum AppError {
-    I2cError(embedded_hal::i2c::Error), // I2Cエラーをラップする
+pub enum AppError<E> where E: embedded_hal::i2c::Error {
+    I2cError(E), // I2Cエラーをラップする
     BuilderError,                     // `()`から発生するエラー用
     // 必要に応じて他のエラー型を追加
 }
 
 // arduino_hal::i2c::Error から AppError への変換
-impl From<Error> for AppError {
-    fn from(e: embedded_hal::i2c::Error) -> Self {
+impl<E> From<E> for AppError<E> where E: embedded_hal::i2c::Error {
+    fn from(e: E) -> Self {
         AppError::I2cError(e)
     }
 }
 
 // `E: From<()>` の要件を満たすために From<()> を実装
-impl From<()> for AppError {
+impl<E> From<()> for AppError<E>
+where
+    E: embedded_hal::i2c::Error,
+{
     fn from(_: ()) -> Self {
         AppError::BuilderError
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,3 +23,25 @@ impl<I2cE> From<I2cE> for Sh1107gError<I2cE> {
         Sh1107gError::I2cError(e)
     }
 }
+
+// src/main.rs または専用のerrorsモジュールに記述
+#[derive(Debug)]
+pub enum AppError {
+    I2cError(embedded_hal::i2c::Error), // I2Cエラーをラップする
+    BuilderError,                     // `()`から発生するエラー用
+    // 必要に応じて他のエラー型を追加
+}
+
+// arduino_hal::i2c::Error から AppError への変換
+impl From<Error> for AppError {
+    fn from(e: embedded_hal::i2c::Error) -> Self {
+        AppError::I2cError(e)
+    }
+}
+
+// `E: From<()>` の要件を満たすために From<()> を実装
+impl From<()> for AppError {
+    fn from(_: ()) -> Self {
+        AppError::BuilderError
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,25 @@
+// Define error enum in builder
+#[derive(Debug)]
+pub enum BuilderError {
+    NoI2cConnected,
+    InitFailed,
+    // NoDisplaySizeDefined, // サイズが必須の場合
+}
+
+#[derive(Debug)]
+pub enum Sh1107gError<I2cE> {
+    Builder(BuilderError),
+    PayloadOverflow,
+    I2cError(I2cE),
+}
+
+// embedded-halのErrorトレイトにも対応させる必要があるかもしれません
+// impl embedded_hal::i2c::Error for BuilderError { ... }
+// impl From<BuilderError> for YourDriverError { ... } など
+
+// From 実装で ? を使えるように
+impl<I2cE> From<I2cE> for Sh1107gError<I2cE> {
+    fn from(e: I2cE) -> Self {
+        Sh1107gError::I2cError(e)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,13 +32,6 @@ pub enum AppError<E> where E: embedded_hal::i2c::Error {
     // 必要に応じて他のエラー型を追加
 }
 
-// arduino_hal::i2c::Error から AppError への変換
-impl<E> From<E> for AppError<E> where E: embedded_hal::i2c::Error {
-    fn from(e: E) -> Self {
-        AppError::I2cError(e)
-    }
-}
-
 // `E: From<()>` の要件を満たすために From<()> を実装
 impl<E> From<()> for AppError<E>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 /// SH1107G I2C OLED driver
 pub mod cmds;
+pub mod error;
 
 #[cfg(feature = "sync")]
 pub mod sync;
@@ -96,32 +97,6 @@ impl<I2C> Sh1107gBuilder<I2C> {
     }
 
     // If you need other method, add other setting method, example: size,rotate,etc...
-}
-
-// Define error enum in builder
-#[derive(Debug)]
-pub enum BuilderError {
-    NoI2cConnected,
-    InitFailed,
-    // NoDisplaySizeDefined, // サイズが必須の場合
-}
-
-#[derive(Debug)]
-pub enum Sh1107gError<I2cE> {
-    Builder(BuilderError),
-    PayloadOverflow,
-    I2cError(I2cE),
-}
-
-// embedded-halのErrorトレイトにも対応させる必要があるかもしれません
-// impl embedded_hal::i2c::Error for BuilderError { ... }
-// impl From<BuilderError> for YourDriverError { ... } など
-
-// From 実装で ? を使えるように
-impl<I2cE> From<I2cE> for Sh1107gError<I2cE> {
-    fn from(e: I2cE) -> Self {
-        Sh1107gError::I2cError(e)
-    }
 }
 
 // define display size

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -3,10 +3,11 @@
 use embedded_hal::i2c::I2c;
 
 #[cfg(feature = "sync")]
-use crate::Sh1107gError;
+use crate::error::Sh1107gError;
 
 #[cfg(feature = "sync")]
-use crate::{BuilderError, Sh1107g, Sh1107gBuilder};
+use crate::{Sh1107g, Sh1107gBuilder};
+use crate::error::BuilderError;
 
 #[cfg(feature = "sync")]
 use core::result::Result;


### PR DESCRIPTION
## Created error module
 - This change new feature that custom error.
 - The biggest change is that we wrapped the I2C error type of the embedded_hal crate.
 - This change will improve the development experience and enable more flexible error handling.